### PR TITLE
DE2455: Optimized builds fail due to "variable was declared but never referenced". In Stopwatch.h, maybe more.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ PROJECT_BASE_NAME = sqlite3
 #  222-D: floating-point operation result is out of range
 #  550-D: variable "nPageHeader" was set but never used
 # 1293-D: assignment in condition
-DIAGFLAGS += --diag_remark=177,222,550,1293
+# C3017W: XXXX may be used before being set
+#
+DIAGFLAGS += --diag_remark=177,222,550,1293,3017
 
 PROJECTFLAGS += -DSQLITE_OS_OTHER=1
 PROJECTFLAGS += -DSQLITE_ENABLE_MEMSYS3


### PR DESCRIPTION
Also see https://github.com/Vorne/build-internal/pull/33.
