### PR TITLE
DE5685: Tell sqlite we have usleep, so don't sleep for whole seconds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ SQLITE3_LIBRARY := $(OUTPUT_DIR)/$(SQLITE3_LIB_NAME)
 SQLITE3_FILES = $(shell find . -name "*.c" -or -name "*.h")
 SQLITE3_FILES += Makefile
 
+# From http://beets.io/blog/sqlite-nightmare.html
+CFLAGS += -DHAVE_USLEEP=1
+
 ################################################################################
 ## SQLite3 Target ##############################################################
 ################################################################################


### PR DESCRIPTION
We may have been compiling sqlite to sleep for whole seconds instead of microseconds.

From `sqlite.c`:
```c
/*
** Sleep for a little while.  Return the amount of time slept.
** The argument is the number of microseconds we want to sleep.
** The return value is the number of microseconds of sleep actually
** requested from the underlying operating system, a number which
** might be greater than or equal to the argument, but not less
** than the argument.
*/
static int unixSleep(sqlite3_vfs *NotUsed, int microseconds){
#if OS_VXWORKS
  struct timespec sp;

  sp.tv_sec = microseconds / 1000000;
  sp.tv_nsec = (microseconds % 1000000) * 1000;
  nanosleep(&sp, NULL); 
  UNUSED_PARAMETER(NotUsed);
  return microseconds;
#elif defined(HAVE_USLEEP) && HAVE_USLEEP
  usleep(microseconds);
  UNUSED_PARAMETER(NotUsed);
  return microseconds;
#else
  int seconds = (microseconds+999999)/1000000;
  sleep(seconds);
  UNUSED_PARAMETER(NotUsed);
  return seconds*1000000;
#endif
}
```