### PR TITLE
US2231, TA7590: Allow xl build finer grain control of library output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ SQLITE3_DIR := .
 SQLITE3_LIB_NAME := libsqlite3.a
 SILENCE_WARNINGS := -Wno-deprecated-declarations
 
-SQLITE3_LIBRARY := $(OUTPUT_DIR)/$(SQLITE3_LIB_NAME)
+# Fall back to OUTPUT_DIR. Keeps this build working if there is a mismatch with the xl repo.
+LIBRARY_OUTPUT_DIR ?= $(OUTPUT_DIR)
+
+SQLITE3_LIBRARY := $(LIBRARY_OUTPUT_DIR)/$(SQLITE3_LIB_NAME)
 
 SQLITE3_FILES = $(shell find . -name "*.c" -or -name "*.h")
 SQLITE3_FILES += Makefile
@@ -44,10 +47,10 @@ $(SQLITE3_LIBRARY): $(SQLITE3_FILES)
 	fi
 
 	@echo Done building SQLite3.
-	@echo 
+	@echo
 
 sqlite3: $(SQLITE3_LIBRARY)
 all: sqlite3
 
 clean:
-	rm -rf $(OUTPUT_DIR)
+	rm -rf $(LIBRARY_OUTPUT_DIR)


### PR DESCRIPTION
In order for our xl SQL functions to be compiled into a shared library, we need to compile all files with `-fPIC` (Position Independent Code), including libraries such as this. However, PIC has performance impacts, so we don't want to always compile with `-fPIC`. So, we want to be able to compile two versions of our libraries, those to be included in the xl process and those to be included in shared objects.

We don't actually use this repo when building the xl SQL functions shared library, but it must follow the convention in order to continue to compile.

I added a fall-back mechanism here, so this can be merged ahead of the XL changes.