### PR TITLE
US2426, TA8267: Enable FTS5 in our sqlite3 static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SQLITE3_FILES += Makefile
 
 # From http://beets.io/blog/sqlite-nightmare.html
 CFLAGS += -DHAVE_USLEEP=1
+CFLAGS += -DSQLITE_ENABLE_FTS5
 
 ################################################################################
 ## SQLite3 Target ##############################################################


### PR DESCRIPTION
It probably wouldn't hurt to go ahead and merge this to master/2.12, but I'll keep it out for now.

I'm going to create another task to update our `sqlite3` package in Yocto. You can still open the database from the command line, you just can't query against the fts5 table. Queries against our other tables works fine though.